### PR TITLE
줄바꿈 문제 해결, 설명창 배경색 light grey 설정

### DIFF
--- a/GitPractice/src/View/CommandExplainDialog.java
+++ b/GitPractice/src/View/CommandExplainDialog.java
@@ -1,23 +1,37 @@
 package View;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
 
 import javax.swing.*;
+import java.awt.FlowLayout;
 
 public class CommandExplainDialog extends JFrame {
-	private JLabel jlb = new JLabel("");
+	
+	private JTextArea explainArea = new JTextArea("");
 	
 	public CommandExplainDialog(String str) {
-		JPanel pane = new JPanel();
-		pane.add(jlb);
-		pane.setBorder(BorderFactory.createEmptyBorder(10 , 10 , 10 , 10));	//내부 패딩 설정
-		jlb.setText(str.toString());
 		
-		this.add(pane, BorderLayout.WEST);
-		this.setMinimumSize(new Dimension(500,200));	//최소 크기 설정
+		JPanel pane = new JPanel();
+		FlowLayout flowLayout = (FlowLayout) pane.getLayout();
+        pane.setBackground(Color.LIGHT_GRAY);
+		explainArea.setEditable(false);
+		explainArea.setBackground(Color.LIGHT_GRAY);
+		pane.add(explainArea);
+		pane.setBorder(BorderFactory.createEmptyBorder(10 , 10 , 10 , 10));	//내부 패딩 설정
+		explainArea.setText(str.toString());
+		
+		getContentPane().add(pane, BorderLayout.WEST);
+		
+		JScrollBar explainScrollBar = new JScrollBar();
+		getContentPane().add(explainScrollBar, BorderLayout.EAST);
+		//explainScrollBar.setBounds(10, 40, 13, 325);
+
 		this.pack();
 		this.setLocation(200,200);
+		//this.setMaximumSize(new Dimension(30,20));
 		this.setVisible(true);
 	}
+
 }


### PR DESCRIPTION
한 줄로 explain 이 나오는 현상을 해결했습니다.
설명창의 배경색을 light grey로 설정하여 가독성을 높였습니다.

현재 스크롤바를 구현중인데
explain의 text가 길어져도 **스크롤바가 스크롤이 안 되는 현상**이 발생합니다.
absolute를 풀거나 자동으로 크기가 늘어나는 부분을
**고정하도록 수정해야 할 것 같습니다.**