### PR TITLE
도형 그래프 그릴 그래픽 작업 중..

### DIFF
--- a/GitPractice/src/View/MainFrame.java
+++ b/GitPractice/src/View/MainFrame.java
@@ -9,6 +9,24 @@ public class MainFrame extends JFrame {
 	static JPanel contentPane;
 	static JTextField textField;
 
+		Container container; //그래프 그릴 작업 중
+		
+		void GraphicsColorFontEx() {
+			container = getContentPane();
+			MyPanel panel = new MyPanel();
+			container.add(panel , BorderLayout.CENTER);
+			setVisible(true);
+		}
+		
+		class MyPanel extends JPanel {
+		public void paintComponent(Graphics g) { //그래픽 TEST, 지금 실행 자체가 안됨..ㅠ
+		super.paintComponent(g);
+		g.setColor(Color.BLUE);
+		g.drawString("Test", 30,30);
+
+		}
+		}
+
 	//실행
 	public static void main(String[] args) {
 		EventQueue.invokeLater(new Runnable() {
@@ -35,9 +53,12 @@ public class MainFrame extends JFrame {
 		new CommandIndexPane();
 		new CommandInputPane();		
 		new CommitGraphPane();
+		//new DrawingGraph(); //그래픽 작업 중, 커밋그래프를 그려줌
 		new TemporaryExplorerPane();
-		
 		this.setJMenuBar(new SettingMenuBar());
+		new GraphicsColorFontEx();
 		
 	}
+	
+	
 }


### PR DESCRIPTION
그래프를 CommitGraphPane에 그리는 것이 맞지만
java swing은 Frame 을 상속해야 그 위에 도형을 그릴 수 있습니다..

따라서 지금 어쩔 수 없이 MainFrame에다 작업을 하고 있으나,
MainFrame의 구성요소와 패널들이 너무 많은 탓에
그림이 위로 안 떠오르는 현상이 발생하고 있습니다..